### PR TITLE
add missing dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  - libxcrypt=4.4.36
   - bioawk=1.0
   - biopython=1.78
   - blast=2.11.0


### PR DESCRIPTION
Add libxcrypt dependency so datrie wheel can be built without changing the python version (previous PR that was closed due to the subsequent errors found after changing the python version)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated an underlying dependency to enhance environment stability and maintain smooth functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->