### PR TITLE
Rename complet_taxo_dic_v3.py to complet_taxo_dic.py

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -562,7 +562,7 @@ rule get_nr_lineage_from_taxids:
 
 	params:
 		getr=scriptdir+"get_rank.py",
-		com=scriptdir+"complet_taxo_dic_v3.py",
+		com=scriptdir+"complet_taxo_dic.py",
 		pickle_shi=scriptdir+"correc_taxo.pickle",
 		pickle_cust=scriptdir+"custom_taxo.pickle"
 	shell:
@@ -620,7 +620,7 @@ rule complete_taxo:
 
 	params:
 		script_mult =scriptdir+"multihit.py",
-		script_compt =scriptdir+"complet_taxo_dic_v3.py",
+		script_compt =scriptdir+"complet_taxo_dic.py",
 		pickle_shi=scriptdir+"correc_taxo.pickle",
 		pickle_cust=scriptdir+"custom_taxo.pickle"
 	shell:


### PR DESCRIPTION
The available script in snakevirome/scripts/ is complet_taxo_dic.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the backend taxonomy data processing to use a revised taxonomy mapping script for improved handling of taxonomy data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->